### PR TITLE
general: return object isn't assignable to ISummaly

### DIFF
--- a/src/general.ts
+++ b/src/general.ts
@@ -14,7 +14,7 @@ client.timeout = 10000;
 
 import ISummary from './isummary';
 
-export default async (url: URL.Url): Promise<ISummary> => {
+export default async (url: URL.Url) => {
 	const res = await client.fetch(url.href);
 
 	if (res.error) {


### PR DESCRIPTION
`Promise<ISummaly>`に合わせようとしていますが実際にはurlを持っていない為コンパイルエラーとなります。