### PR TITLE
[package] remove some unneed @types dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   },
   "devDependencies": {
     "@types/debug": "0.0.29",
-    "@types/express": "4.0.35",
-    "@types/mocha": "2.2.40",
     "@types/node": "7.0.14",
     "@types/request": "0.0.42",
     "express": "4.14.1",


### PR DESCRIPTION
JavaScriptで利用するだけ (mochaのスクリプトはJavaScriptなので) なモジュール用の型情報を入れておく必要はないと感じます