### PR TITLE
Fix: cause 500 when no url

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,11 @@ import summaly from '../';
 const app = new Koa();
 
 app.use(async ctx => {
+	if (!ctx.query.url) {
+		ctx.status = 400;
+		return;
+	}
+
 	try {
 		const summary = await summaly(ctx.query.url, {
 			followRedirects: false


### PR DESCRIPTION
serverで`url`が指定されてない時に試行して500になってしまうのを修正