### PR TITLE
Amazonで動作しないのを修正

### DIFF
--- a/src/general.ts
+++ b/src/general.ts
@@ -14,7 +14,7 @@ client.set('headers', {
 });
 client.set('referer', false);
 client.set('timeout', 10000);
-client.set('maxDataSize', 1024 * 1024);
+client.set('maxDataSize', 5 * 1024 * 1024);
 
 import Summary from './summary';
 

--- a/src/plugins/amazon.ts
+++ b/src/plugins/amazon.ts
@@ -52,10 +52,10 @@ export async function summarize(url: URL.Url): Promise<summary> {
 		$('meta[name="twitter:player:height"]').attr('content'));
 
 	return {
-		title: title || null,
+		title: title ? title.trim() : null,
 		icon: 'https://www.amazon.com/favicon.ico',
-		description: description || null,
-		thumbnail: thumbnail || null,
+		description: description ? description.trim() : null,
+		thumbnail: thumbnail ? thumbnail.trim() : null,
 		player: {
 			url: playerUrl || null,
 			width: playerWidth || null,

--- a/src/plugins/amazon.ts
+++ b/src/plugins/amazon.ts
@@ -8,6 +8,7 @@ client.set('headers', {
 });
 client.set('referer', false);
 client.set('timeout', 10000);
+client.set('maxDataSize', 5 * 1024 * 1024);
 
 export function test(url: URL.Url): boolean {
 	return url.hostname === 'www.amazon.com' ||


### PR DESCRIPTION
Amazonで動作しないのを修正

- ページサイズが1MBを超えているため1MB制限だと動かないので5MBに修正
  (cheerio-httpcliが単一インスタンスのためgenericの方の1MB制限が適用されちゃう)
- thumbnailのData-URIの先頭に改行が入ってしまってうまくいかないのを修正
- title, description に無駄な空白文字が入ってしまうのを修正
![image](https://user-images.githubusercontent.com/30769358/64079903-c2143180-cd28-11e9-9077-2d2d632cbc3e.png)


