### PR TITLE
Twitterのsensitive contentをサポート

### DIFF
--- a/src/general.ts
+++ b/src/general.ts
@@ -97,6 +97,8 @@ export default async (url: URL.Url, lang: string = null): Promise<Summary> => {
 		$('link[rel="icon"]').attr('href') ||
 		'/favicon.ico';
 
+	const sensitive = $('.tweet').attr('data-possibly-sensitive') === 'true'
+
 	const find = (path: string) => new Promise<string>(done => {
 		const target = URL.resolve(url.href, path);
 		request.head(target, (err, res) => {
@@ -146,6 +148,7 @@ export default async (url: URL.Url, lang: string = null): Promise<Summary> => {
 			width: playerWidth || null,
 			height: playerHeight || null
 		},
-		sitename: siteName || null
+		sitename: siteName || null,
+		sensitive,
 	};
 };

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -28,6 +28,11 @@ type Summary = {
 	 * The title of that web page
 	 */
 	title: string;
+
+	/**
+	 * Possibly sensitive
+	 */
+	sensitive?: boolean;
 };
 
 export default Summary;


### PR DESCRIPTION
Twitterのツイートで
「このメディアにはセンシティブな内容が含まれている可能性があります。」の場合でも
サムネイルが普通に表示されてしまうので

検知できる場合は`sensitive`フラグを返してあげるようにしています。