### PR TITLE
Twitterのプレビューができなくなっているのを修正

### DIFF
--- a/src/general.ts
+++ b/src/general.ts
@@ -9,8 +9,10 @@ import { AllHtmlEntities } from 'html-entities';
 const entities = new AllHtmlEntities();
 
 import * as client from 'cheerio-httpcli';
+
+// 単一インスタンスなのでamazonと値を揃えないといけない
 client.set('headers', {
-  'User-Agent': `${name}/${version}`
+	'User-Agent': `SummalyBot/${version}`
 });
 client.set('referer', false);
 client.set('timeout', 10000);

--- a/src/general.ts
+++ b/src/general.ts
@@ -16,7 +16,7 @@ client.set('headers', {
 });
 client.set('referer', false);
 client.set('timeout', 10000);
-client.set('maxDataSize', 5 * 1024 * 1024);
+client.set('maxDataSize', 10 * 1024 * 1024);
 
 import Summary from './summary';
 

--- a/src/plugins/amazon.ts
+++ b/src/plugins/amazon.ts
@@ -7,7 +7,7 @@ client.set('headers', {
 	'User-Agent': `SummalyBot/${version}`
 });
 client.set('referer', false);
-client.set('timeout', 20000);
+client.set('timeout', 10000);
 client.set('maxDataSize', 10 * 1024 * 1024);
 
 export function test(url: URL.Url): boolean {

--- a/src/plugins/amazon.ts
+++ b/src/plugins/amazon.ts
@@ -4,11 +4,11 @@ import * as client from 'cheerio-httpcli';
 import summary from '../summary';
 
 client.set('headers', {
-  'User-Agent': `${name}/${version}`
+	'User-Agent': `SummalyBot/${version}`
 });
 client.set('referer', false);
-client.set('timeout', 10000);
-client.set('maxDataSize', 5 * 1024 * 1024);
+client.set('timeout', 20000);
+client.set('maxDataSize', 10 * 1024 * 1024);
 
 export function test(url: URL.Url): boolean {
 	return url.hostname === 'www.amazon.com' ||


### PR DESCRIPTION
Twitterのプレビューができなくなっているのを修正
`Bot`ぽいUAにしないと`og`出してくれなくなったみたい

たまに5MBじゃ足りないページがあるのでサイズ制限を10MBに