### PR TITLE
Supports multi instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
   },
   "devDependencies": {
     "@types/debug": "0.0.30",
-    "@types/express": "4.16.0",
+    "@types/express": "4.17.3",
     "@types/html-entities": "1.2.16",
     "@types/mocha": "5.2.2",
-    "@types/node": "10.3.4",
+    "@types/node": "16.4.1",
     "@types/request": "2.47.1",
     "@types/request-promise-native": "1.0.15",
     "express": "4.16.3",
     "mocha": "5.2.0",
-    "typescript": "2.9.2"
+    "typescript": "4.3.5"
   },
   "dependencies": {
-    "cheerio-httpcli": "0.7.4",
+    "cheerio-httpcli": "0.8.2",
     "debug": "3.1.0",
     "escape-regexp": "0.0.1",
     "html-entities": "1.2.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,13 @@
+import { version } from '../package.json';
+import * as client from 'cheerio-httpcli';
+
+client.set('headers', {
+	'User-Agent': `SummalyBot/${version}`
+});
+client.set('referer', false);
+client.set('timeout', 20000);
+client.set('maxDataSize', 10 * 1024 * 1024);
+
+export function createInstance() {
+	return client.fork();
+}

--- a/src/general.ts
+++ b/src/general.ts
@@ -1,4 +1,3 @@
-import { name, version } from '../package.json';
 import * as URL from 'url';
 import * as request from 'request';
 import nullOrEmpty from './utils/null-or-empty';
@@ -8,20 +7,13 @@ import cleanupTitle from './utils/cleanup-title';
 import { AllHtmlEntities } from 'html-entities';
 const entities = new AllHtmlEntities();
 
-import * as client from 'cheerio-httpcli';
-
-// 単一インスタンスなのでamazonと値を揃えないといけない
-client.set('headers', {
-	'User-Agent': `SummalyBot/${version}`
-});
-client.set('referer', false);
-client.set('timeout', 10000);
-client.set('maxDataSize', 10 * 1024 * 1024);
-
+import { createInstance } from './client';
 import Summary from './summary';
 
 export default async (url: URL.Url, lang: string = null): Promise<Summary> => {
 	if (lang && !lang.match(/^[\w-]+(\s*,\s*[\w-]+)*$/)) lang = null;
+
+	const client = createInstance();
 
 	client.set('headers', {
 		'Accept-Language': lang

--- a/src/plugins/amazon.ts
+++ b/src/plugins/amazon.ts
@@ -1,14 +1,6 @@
-import { name, version } from '../../package.json';
 import * as URL from 'url';
-import * as client from 'cheerio-httpcli';
+import { createInstance } from '../client';
 import summary from '../summary';
-
-client.set('headers', {
-	'User-Agent': `SummalyBot/${version}`
-});
-client.set('referer', false);
-client.set('timeout', 10000);
-client.set('maxDataSize', 10 * 1024 * 1024);
 
 export function test(url: URL.Url): boolean {
 	return url.hostname === 'www.amazon.com' ||
@@ -28,6 +20,8 @@ export function test(url: URL.Url): boolean {
 }
 
 export async function summarize(url: URL.Url): Promise<summary> {
+	const client = createInstance();
+
 	const res = await client.fetch(url.href);
 	const $ = res.$;
 


### PR DESCRIPTION
マルチインスタンス対応とビルドの修正
Fix #142 
Related #143 https://github.com/misskey-dev/misskey/issues/7428

マルチインスタンス対応 ([cheerio-httpcli v0.8.0 (2020-06-11)](https://github.com/ktty1220/cheerio-httpcli/blob/master/CHANGELOG.md#080-2020-06-11) の機能)
オプション等が前回または同時に動いているインスタンスと共用されてしまう問題を修正。

[cheerio-httpcli v0.8.2 (2021-07-22)](https://github.com/ktty1220/cheerio-httpcli/blob/master/CHANGELOG.md#082-2021-07-22) に上げれば`shrinkwrap`等のlock機構を使用しなくてもビルドできるようになったので
そこまで上げてます。

なるべく関係ないdependenciesは更新していませんが
`@types/express` => `@types/node` => `typescript` だけはどうしても更新する必要があったので更新しています。

タイムアウトを増やしているのは、たまに応答の遅いサイトに何回もリクエストしてしまう問題があったからな気がしたけど忘れた。