### PR TITLE
enhance: accept XHTML

### DIFF
--- a/src/utils/got.ts
+++ b/src/utils/got.ts
@@ -15,11 +15,11 @@ export async function scpaping(url: string, opts?: { lang?: string; }) {
 		url,
 		method: 'GET',
 		headers: {
-			'accept': 'text/html',
+			'accept': 'text/html,application/xhtml+xml',
 			'user-agent': BOT_UA,
 			'accept-language': opts?.lang
 		},
-		typeFilter: /^text\/html/,
+		typeFilter: /^(text\/html|application\/xhtml\+xml)/,
 	});
 
 	// テスト用


### PR DESCRIPTION
Fixes #148.

I used `https://www.alm.website/blog/2022-06-25-note-1` as an example page that will currently be returned as XHTML only, and it seemed to work:
![image](https://user-images.githubusercontent.com/20990607/175791674-45a83457-882d-4b56-b7cd-ee84212276bb.png)
