### PR TITLE
Upgrade got to v11.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "cheerio": "0.22.0",
         "debug": "4.3.3",
         "escape-regexp": "0.0.1",
-        "got": "11.5.1",
+        "got": "11.8.5",
         "html-entities": "2.3.2",
         "iconv-lite": "0.6.3",
         "jschardet": "3.0.0",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-      "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "engines": {
         "node": ">=10"
       },
@@ -1012,18 +1012,18 @@
       }
     },
     "node_modules/got": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.5.1.tgz",
-      "integrity": "sha512-reQEZcEBMTGnujmQ+Wm97mJs/OK6INtO6HmLI+xt3+9CvnRwWjXutUvb2mqr+Ao4Lu05Rx6+udx9sOQAmExMxA==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dependencies": {
-        "@sindresorhus/is": "^3.0.0",
+        "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
         "p-cancelable": "^2.0.0",
         "responselike": "^2.0.0"
@@ -2326,9 +2326,9 @@
   },
   "dependencies": {
     "@sindresorhus/is": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-      "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -3095,18 +3095,18 @@
       }
     },
     "got": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.5.1.tgz",
-      "integrity": "sha512-reQEZcEBMTGnujmQ+Wm97mJs/OK6INtO6HmLI+xt3+9CvnRwWjXutUvb2mqr+Ao4Lu05Rx6+udx9sOQAmExMxA==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "requires": {
-        "@sindresorhus/is": "^3.0.0",
+        "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
         "p-cancelable": "^2.0.0",
         "responselike": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cheerio": "0.22.0",
     "debug": "4.3.3",
     "escape-regexp": "0.0.1",
-    "got": "11.5.1",
+    "got": "11.8.5",
     "html-entities": "2.3.2",
     "iconv-lite": "0.6.3",
     "jschardet": "3.0.0",


### PR DESCRIPTION
gotを v11.8.5 に更新。
ここの got の dependencies が Misskeyとかで CVE-2022-33987 にかかるため。